### PR TITLE
Add missing utils for embedded-tables FE

### DIFF
--- a/embedded-tables/frontend/app/components/ui/lib/utils.ts
+++ b/embedded-tables/frontend/app/components/ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+ 
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
This is actually a workaround. Better to init shad using npx and add components using npx as well, that way can put utils under `/lib` in root.